### PR TITLE
prefix categories on NSObject

### DIFF
--- a/Tolo/Tolo/Tolo.m
+++ b/Tolo/Tolo/Tolo.m
@@ -46,11 +46,11 @@
 @end
 
 @interface NSObject (PubSub)
-- (NSDictionary *)selectorsWithPrefix:(NSString *)prefix withParam:(BOOL)hasParam;
+- (NSDictionary *)tolo_selectorsWithPrefix:(NSString *)prefix withParam:(BOOL)hasParam;
 @end
 @implementation NSObject (PubSub)
 
-- (NSDictionary *)selectorsWithPrefix:(NSString *)prefix withParam:(BOOL)hasParam
+- (NSDictionary *)tolo_selectorsWithPrefix:(NSString *)prefix withParam:(BOOL)hasParam
 {
     NSMutableDictionary *result = [NSMutableDictionary dictionary];
     
@@ -128,7 +128,7 @@
         self.publishers = [NSMutableDictionary dictionary];
     }
     
-    NSDictionary *publishingObjects = [object selectorsWithPrefix:self.publisherPrefix withParam:NO];
+    NSDictionary *publishingObjects = [object tolo_selectorsWithPrefix:self.publisherPrefix withParam:NO];
     
     if (publishingObjects.count) {
         
@@ -149,7 +149,7 @@
     if (!self.observers) {
         self.observers = [NSMutableDictionary dictionary];
     }
-    NSDictionary *observedObjects = [object selectorsWithPrefix:self.observerPrefix withParam:YES];
+    NSDictionary *observedObjects = [object tolo_selectorsWithPrefix:self.observerPrefix withParam:YES];
     
     if (observedObjects.count) {
         


### PR DESCRIPTION
The non-prefixed category `selectorWithPrefix:withParam:` potentially causes a clash with other libraries (it does in our app, although sadly I could not find out what other lib defined this category...).

Thus I prefixed the category with `tolo_`, as common in Objective C best practices for libraries.
